### PR TITLE
Update oauth2 authorize endpoint to my.mollie

### DIFF
--- a/source/reference/oauth2/authorize.rst
+++ b/source/reference/oauth2/authorize.rst
@@ -4,7 +4,7 @@ Authorize
 
 .. endpoint::
    :method: GET
-   :url: https://www.mollie.com/oauth2/authorize
+   :url: https://my.mollie.com/oauth2/authorize
 
 .. note:: You should construct the Authorize URL from the endpoint above with the parameters below. Then, you should
           redirect the resource owner to the Authorize endpoint.


### PR DESCRIPTION
Oauth2 is one of the paths that require authentication and that are served from my.mollie.com.
Even though the platform takes care of redirecting 'old' requests, the documentation should reflect the new rules.